### PR TITLE
 🌈feat : 유니코드 범위로 한글만 Noto Sans KR 적용

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,7 @@
 	src: url('styles/fonts/NotoSansKR-Light.woff2') format('woff2'),
 		url('styles/fonts/NotoSansKR-Light.woff') format('woff'),
 		url('styles/fonts/NotoSansKR-Light.otf') format('truetype');
+	unicode-range: U+AC00-D7A3;
 }
 
 @font-face {
@@ -15,6 +16,7 @@
 	src: url('styles/fonts/NotoSansKR-Regular.woff2') format('woff2'),
 		url('styles/fonts/NotoSansKR-Regular.woff') format('woff'),
 		url('styles/fonts/NotoSansKR-Regular.otf') format('truetype');
+	unicode-range: U+AC00-D7A3;
 }
 
 @font-face {
@@ -24,6 +26,7 @@
 	src: url('styles/fonts/NotoSansKR-Medium.woff2') format('woff2'),
 		url('styles/fonts/NotoSansKR-Medium.woff') format('woff'),
 		url('styles/fonts/NotoSansKR-Medium.otf') format('truetype');
+	unicode-range: U+AC00-D7A3;
 }
 
 @font-face {
@@ -33,6 +36,7 @@
 	src: url('styles/fonts/NotoSansKR-Bold.woff2') format('woff2'),
 		url('styles/fonts/NotoSansKR-Bold.woff') format('woff'),
 		url('styles/fonts/NotoSansKR-Bold.otf') format('truetype');
+	unicode-range: U+AC00-D7A3;
 }
 
 @font-face {
@@ -57,13 +61,14 @@
 
 body {
 	margin: 0;
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Oxygen', 'Ubuntu',
-		'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+	font-family: 'Noto Sans CJK KR', 'Roboto', -apple-system, BlinkMacSystemFont,
+		'Segoe UI', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+		'Helvetica Neue', sans-serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
 
 code {
-	font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-		monospace;
+	font-family: 'Noto Sans CJK KR', 'Roboto', source-code-pro, Menlo, Monaco,
+		Consolas, 'Courier New', monospace;
 }


### PR DESCRIPTION
### 요약 (Summary)

- 유니코드 범위로 한글 폰트만 Noto Sans KR font-family 적용

### 바뀐 점 (Changes)

- css에 속성 추가
- unicode-range: U+AC00-D7A3;

