### PR TITLE
🌈feat : MSkeleton.stories.jsx

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from 'react-query'
 import { RouterProvider } from 'react-router-dom'
 import { RecoilRoot } from 'recoil'
 import { ThemeProvider } from 'styled-components'
@@ -10,13 +11,16 @@ function App() {
 	if (process.env.NODE_ENV === 'development') {
 		worker.start()
 	}
+	const queryClient = new QueryClient()
 
 	return (
 		<>
 			<ThemeProvider theme={theme}>
-				<RecoilRoot>
-					<RouterProvider router={router} />
-				</RecoilRoot>
+				<QueryClientProvider client={queryClient}>
+					<RecoilRoot>
+						<RouterProvider router={router} />
+					</RecoilRoot>
+				</QueryClientProvider>
 			</ThemeProvider>
 		</>
 	)

--- a/src/components/ui/atoms/Skeleton/MSkeleton.jsx
+++ b/src/components/ui/atoms/Skeleton/MSkeleton.jsx
@@ -1,0 +1,36 @@
+import { Skeleton } from '@mui/material'
+import PropTypes from 'prop-types'
+
+export const MSkeleton = ({ ...args }) => {
+	return <Skeleton {...args} />
+}
+
+MSkeleton.propTypes = {
+	/**
+	 * 스켈레톤의 형태를 골라주세요
+	 */
+	variant: PropTypes.oneOf(['text', 'circular', 'rectangular', 'rounded']),
+	/**
+	 * 가로길이를 적어주세요
+	 */
+	width: PropTypes.number,
+	/**
+	 * 세로길이를 적어주세요
+	 */
+	height: PropTypes.number,
+	/**
+	 * 스켈레톤의 애니메이션 상태를 골라주세요
+	 */
+	animation: PropTypes.oneOf([false, 'wave']),
+	/**
+	 * 스켈레톤의 추가설정을 할 수 있습니다.
+	 */
+	sx: PropTypes.shape({}),
+}
+
+MSkeleton.defaultProps = {
+	variant: 'text',
+	animation: undefined,
+}
+
+export default MSkeleton

--- a/src/components/ui/atoms/Skeleton/MSkeleton.stories.jsx
+++ b/src/components/ui/atoms/Skeleton/MSkeleton.stories.jsx
@@ -1,0 +1,55 @@
+import MSkeleton from './MSkeleton'
+
+export default {
+	title: 'Atom/MSkeleton',
+	tags: ['autodocs'],
+	component: MSkeleton,
+	argTypes: {
+		variant: {
+			control: {
+				type: 'select',
+			},
+			options: ['text', 'circular', 'rectangular', 'rounded'],
+		},
+		width: { control: { type: 'number' } },
+		height: { control: { type: 'number' } },
+		animation: {
+			control: {
+				type: 'select',
+			},
+			options: [false, 'wave', undefined],
+		},
+	},
+}
+
+export const 텍스트 = {
+	args: {
+		variant: 'text',
+		width: 200,
+		height: 50,
+	},
+}
+
+export const 원형 = {
+	args: {
+		variant: 'circular',
+		width: 100,
+		height: 100,
+	},
+}
+
+export const 직사각형 = {
+	args: {
+		variant: 'rectangular',
+		width: 200,
+		height: 50,
+	},
+}
+
+export const 둥근모서리 = {
+	args: {
+		variant: 'rounded',
+		width: 200,
+		height: 50,
+	},
+}


### PR DESCRIPTION
### 요약 (Summary)

-  틀을 잡기위해 먼저 Skeleton Ui를 추가하였습니다.

### 바뀐 점 (Changes)

- 기존에 코드에서 QueryClientProvider가 빠져있어 추가하였습니다.


### 특이사항 (Optional)

- 만약 직접 입력한 코드가 아닌 Mui와 같은 라이브러리를 사용한다면 앞에 해당 라이브러리의 이니셜이나 대문자를 붙이는게 어떨까요?

### Screenshots (Optional)


![image](https://github.com/KIT-Frontend-Team2/Paradise_/assets/115636461/47685840-e9f4-45de-b701-c08dfaeb87cf)
![image](https://github.com/KIT-Frontend-Team2/Paradise_/assets/115636461/50eceac1-87c0-43a4-afa5-167157e91f57)
