### PR TITLE
 🌈feat :  스토리북 인풋박스, 인풋그룹 추가

### DIFF
--- a/src/components/ui/atoms/Input/Input.jsx
+++ b/src/components/ui/atoms/Input/Input.jsx
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types'
+
+import S from './style'
+
+const Input = ({ ...args }) => {
+	return <S.Input {...args} />
+}
+
+Input.propTypes = {
+	/**
+	 * plceholder를 입력해주세요
+	 */
+	placeholder: PropTypes.string,
+}
+
+export default Input

--- a/src/components/ui/atoms/Input/Input.stories.jsx
+++ b/src/components/ui/atoms/Input/Input.stories.jsx
@@ -1,0 +1,21 @@
+import { ThemeProvider } from 'styled-components'
+import theme from 'styles/theme'
+
+import Input from './Input'
+
+export default {
+	title: 'Atom/Input',
+	tags: ['autodocs'],
+	component: Input,
+	decorators: [
+		Story => (
+			<ThemeProvider theme={theme}>
+				<Story />
+			</ThemeProvider>
+		),
+	],
+}
+
+export const 인풋박스 = {
+	placeholder: '이메일을 입력해주세요',
+}

--- a/src/components/ui/atoms/Input/style.js
+++ b/src/components/ui/atoms/Input/style.js
@@ -1,0 +1,19 @@
+const { styled } = require('styled-components')
+
+const S = {}
+
+S.Input = styled.input`
+	flex-grow: 1;
+	padding: 0 16px;
+	height: 50px;
+	line-height: 50px;
+	font-size: 18px;
+	color: ${({ theme }) => theme.PALETTE.black};
+	border: 1px solid ${({ theme }) => theme.PALETTE.gray[500]};
+	border-radius: 6px;
+	box-sizing: border-box;
+	&::placeholder {
+		color: #999;
+	}
+`
+export default S

--- a/src/components/ui/molecules/InputGroup.jsx
+++ b/src/components/ui/molecules/InputGroup.jsx
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types'
+
+import Button from '../atoms/Button/Button'
+import Input from '../atoms/Input/Input'
+import S from './style'
+
+const InputGroup = ({ ...args }) => {
+	return <S.InputGroup {...args}>{args.children}</S.InputGroup>
+}
+
+InputGroup.propTypes = {
+	/**
+	 * flex 형식을 골라주세요.
+	 */
+	display: PropTypes.oneOf(['flex', 'inline-flex']),
+}
+
+InputGroup.defaultProps = {
+	display: 'flex',
+	children: (
+		<>
+			<Input placeholder={'이메일을 입력해주세요'} />
+			<Button label={'중복확인'} variant={'outlined'} />
+		</>
+	),
+}
+
+export default InputGroup

--- a/src/components/ui/molecules/InputGroup.stories.jsx
+++ b/src/components/ui/molecules/InputGroup.stories.jsx
@@ -1,0 +1,25 @@
+import { ThemeProvider } from 'styled-components'
+import theme from 'styles/theme'
+
+import InputGroup from './InputGroup'
+
+export default {
+	title: 'Molecules/InputGroup',
+	tags: ['autodocs'],
+	component: InputGroup,
+	decorators: [
+		Story => (
+			<ThemeProvider theme={theme}>
+				<Story />
+			</ThemeProvider>
+		),
+	],
+}
+
+export const flex = {
+	display: 'flex',
+}
+
+export const inline_flex = {
+	display: 'inline-flex',
+}

--- a/src/components/ui/molecules/style.js
+++ b/src/components/ui/molecules/style.js
@@ -1,0 +1,10 @@
+import { styled } from 'styled-components'
+
+const S = {}
+
+S.InputGroup = styled.div`
+	display: ${({ display }) => display};
+	gap: 8px;
+`
+
+export default S


### PR DESCRIPTION
### 요약 (Summary)

- 스토리북 인풋박스, 인풋그룹 추가

### 바뀐 점 (Changes)

- input atom 추가
- input storybook 추가
- input group molecules 추가
- input group storybook 추가


### 특이사항 (Optional)

- input 의 조합을 input group 으로 만들었습니다.
- input + button일수도 있고 button + button 일수도 있고... 여러 케이스를 생각중입니다.
- InputGroup 안에 Input 태그가 하나면 100%로 차게끔 되어있습니다.

### Screenshots (Optional)
<img width="1439" alt="image" src="https://github.com/KIT-Frontend-Team2/Paradise_/assets/11881721/44de9bce-1033-40ca-82f2-f20899d14bce">


<img width="1440" alt="image" src="https://github.com/KIT-Frontend-Team2/Paradise_/assets/11881721/7468e816-504a-47a0-9a09-baaa96575c70">
