### PR TITLE
 🌈feat : 마이페이지 공통 부분(마이페이지 헤더, 마이페이지 메뉴) 추가

### DIFF
--- a/src/atom/mypage/atom.js
+++ b/src/atom/mypage/atom.js
@@ -1,0 +1,6 @@
+import { atom } from 'recoil'
+
+export const myMenuAtom = atom({
+	key: 'myMenuAtom',
+	default: 'mySell',
+})

--- a/src/components/pages/MyPage.jsx
+++ b/src/components/pages/MyPage.jsx
@@ -1,5 +1,39 @@
+import { myMenuAtom } from 'atom/mypage/atom'
+import Container from 'components/layout/Container'
+import MyContent from 'components/templates/MyPageTemplate/MyContent'
+import MyHeader from 'components/ui/organisms/MyHeader/MyHeader'
+import MyMenu from 'components/ui/organisms/MyMenu/MyMenu'
 import React from 'react'
+import { useRecoilState } from 'recoil'
+import { styled } from 'styled-components'
 
-const MyPage = props => <div style={{ height: '3000px' }}>my</div>
+const MyPage = () => {
+	const [myMenu, setMyMenu] = useRecoilState(myMenuAtom)
 
+	return (
+		<>
+			<MyHeader />
+			<Container>
+				<S.Wrapper>
+					<MyMenu />
+					<S.ContentWrap>
+						<MyContent />
+					</S.ContentWrap>
+				</S.Wrapper>
+			</Container>
+		</>
+	)
+}
 export default MyPage
+
+const S = {}
+
+S.Wrapper = styled.div`
+	display: flex;
+	gap: 50px;
+	min-height: 100vh;
+`
+
+S.ContentWrap = styled.div`
+	flex: 1;
+`

--- a/src/components/templates/MyPageTemplate/MyAccountTemplate.jsx
+++ b/src/components/templates/MyPageTemplate/MyAccountTemplate.jsx
@@ -1,0 +1,5 @@
+const MyAccountTemplate = () => {
+	return <div>계정관리 :)</div>
+}
+
+export default MyAccountTemplate

--- a/src/components/templates/MyPageTemplate/MyCashTemplate.jsx
+++ b/src/components/templates/MyPageTemplate/MyCashTemplate.jsx
@@ -1,0 +1,5 @@
+const MyCashTemplate = () => {
+	return <div>가계부 :)</div>
+}
+
+export default MyCashTemplate

--- a/src/components/templates/MyPageTemplate/MyContent.jsx
+++ b/src/components/templates/MyPageTemplate/MyContent.jsx
@@ -1,0 +1,29 @@
+import { myMenuAtom } from 'atom/mypage/atom'
+import { useRecoilValue } from 'recoil'
+
+import MyAccountTemplate from './MyAccountTemplate'
+import MyCashTemplate from './MyCashTemplate'
+import MyRecentTemplate from './MyRecentTemplate'
+import MySellTemplate from './MySellTemplate'
+import MyWishTemplate from './MyWishTemplate'
+
+const MyContent = () => {
+	const myMenu = useRecoilValue(myMenuAtom)
+
+	switch (myMenu) {
+		case 'mySell':
+			return <MySellTemplate />
+		case 'wish':
+			return <MyWishTemplate />
+		case 'recent':
+			return <MyRecentTemplate />
+		case 'cash':
+			return <MyCashTemplate />
+		case 'account':
+			return <MyAccountTemplate />
+		default:
+			return <div>:)</div>
+	}
+}
+
+export default MyContent

--- a/src/components/templates/MyPageTemplate/MyRecentTemplate.jsx
+++ b/src/components/templates/MyPageTemplate/MyRecentTemplate.jsx
@@ -1,0 +1,5 @@
+const MyRecentTemplate = () => {
+	return <div>최근 본 상품 :)</div>
+}
+
+export default MyRecentTemplate

--- a/src/components/templates/MyPageTemplate/MySellTemplate.jsx
+++ b/src/components/templates/MyPageTemplate/MySellTemplate.jsx
@@ -1,0 +1,5 @@
+const MySellTemplate = () => {
+	return <div>등록 상품 :)</div>
+}
+
+export default MySellTemplate

--- a/src/components/templates/MyPageTemplate/MyWishTemplate.jsx
+++ b/src/components/templates/MyPageTemplate/MyWishTemplate.jsx
@@ -1,0 +1,5 @@
+const MyWishTemplate = () => {
+	return <div>관심 상품 :)</div>
+}
+
+export default MyWishTemplate

--- a/src/components/ui/organisms/MyHeader/MyHeader.jsx
+++ b/src/components/ui/organisms/MyHeader/MyHeader.jsx
@@ -1,5 +1,95 @@
-import React from 'react'
+import { headerMock } from '__mock__/datas/header.mock'
+import { myMenuAtom } from 'atom/mypage/atom'
+import { useRecoilState } from 'recoil'
+import { styled } from 'styled-components'
 
-const MyHeader = props => <div>:)</div>
+const MyHeader = () => {
+	const [myMenu, setMyMenu] = useRecoilState(myMenuAtom)
+
+	const onClickMenu = path => {
+		setMyMenu(path)
+	}
+
+	return (
+		<S.Header>
+			<S.Container>
+				<S.ProfileBox>{headerMock.data.user_info.user_nick_name}</S.ProfileBox>
+				<S.Box>
+					<S.Title>등록상품</S.Title>
+					<S.Link
+						className={myMenu === 'mySell' ? 'on' : ''}
+						onClick={() => onClickMenu('mySell')}
+					>
+						0
+					</S.Link>
+				</S.Box>
+				<S.Box>
+					<S.Title>관심상품</S.Title>
+					<S.Link
+						className={myMenu === 'wish' ? 'on' : ''}
+						onClick={() => onClickMenu('wish')}
+					>
+						0
+					</S.Link>
+				</S.Box>
+				<S.Box>
+					<S.Title>채팅</S.Title>
+					<S.Link
+						className={myMenu === 'chat' ? 'on' : ''}
+						onClick={() => window.alert('채팅 오픈')}
+					>
+						0
+					</S.Link>
+				</S.Box>
+			</S.Container>
+		</S.Header>
+	)
+}
 
 export default MyHeader
+
+const S = {}
+
+S.Header = styled.div`
+	background-color: ${({ theme }) => theme.PALETTE.gray[100]};
+	margin-bottom: 30px;
+`
+
+S.Container = styled.div`
+	display: flex;
+	gap: 8px;
+	width: 1100px;
+	margin: 0 auto;
+	padding: 30px 0;
+`
+
+S.ProfileBox = styled.div`
+	flex: 1;
+	background-color: ${({ theme }) => theme.PALETTE.background.white};
+`
+
+S.Box = styled.div`
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	width: 160px;
+	height: 120px;
+	background-color: ${({ theme }) => theme.PALETTE.background.white};
+`
+
+S.Title = styled.span`
+	color: ${({ theme }) => theme.PALETTE.gray[800]};
+	font-size: ${({ theme }) => theme.FONT_SIZE.xsmall};
+`
+
+S.Link = styled.span`
+	margin-top: 4px;
+	font-size: 22px;
+	font-weight: ${({ theme }) => theme.FONT_WEIGHT.bold};
+	cursor: pointer;
+
+	&.on {
+		color: ${({ theme }) => theme.PALETTE.primary[100]};
+	}
+`

--- a/src/components/ui/organisms/MyMenu/MyMenu.jsx
+++ b/src/components/ui/organisms/MyMenu/MyMenu.jsx
@@ -1,0 +1,94 @@
+import { myMenuAtom } from 'atom/mypage/atom'
+import { useRecoilState } from 'recoil'
+import { styled } from 'styled-components'
+
+const MyMenu = () => {
+	const [myMenu, setMyMenu] = useRecoilState(myMenuAtom)
+	const myCategories = [
+		{
+			path: 'mySell',
+			label: '등록 상품',
+		},
+		{
+			path: 'wish',
+			label: '관심 상품',
+		},
+		{
+			path: 'recent',
+			label: '최근 본 상품',
+		},
+		{
+			path: 'cash',
+			label: '가계부',
+		},
+		{
+			path: 'account',
+			label: '계정관리',
+		},
+	]
+	const onClickMenu = path => {
+		setMyMenu(path)
+	}
+	return (
+		<S.MyMenu>
+			<S.MyTitle>나의 활동</S.MyTitle>
+			<ul>
+				{myCategories.map(category => (
+					<li
+						key={category.label}
+						onClick={() => onClickMenu(category.path)}
+						className={myMenu === category.path ? 'on' : ''}
+					>
+						<a>{category.label}</a>
+					</li>
+				))}
+			</ul>
+		</S.MyMenu>
+	)
+}
+
+export default MyMenu
+
+const S = {}
+
+S.MyMenu = styled.div`
+	width: 174px;
+
+	ul {
+		margin: 0;
+		padding: 0;
+		border: 1px solid ${({ theme }) => theme.PALETTE.gray[400]};
+	}
+
+	li {
+		position: relative;
+		list-style: none;
+		height: 50px;
+		line-height: 50px;
+		padding: 0 20px;
+		border-top: 1px solid ${({ theme }) => theme.PALETTE.gray[400]};
+
+		&:first-child {
+			border-top: 0;
+		}
+
+		&.on {
+			::after {
+				content: '';
+				position: absolute;
+				inset: -1px;
+				z-index: 1;
+				border: 1px solid ${({ theme }) => theme.PALETTE.primary[100]};
+			}
+			a {
+				color: ${({ theme }) => theme.PALETTE.primary[200]};
+			}
+		}
+	}
+`
+
+S.MyTitle = styled.div`
+	margin-bottom: 30px;
+	font-size: 28px;
+	font-weight: ${({ theme }) => theme.FONT_SIZE.medium};
+`


### PR DESCRIPTION
### 요약 (Summary)

- 마이페이지 공통 영역 추가

### 바뀐 점 (Changes)

- 마이페이지 헤더 추가
- 마이페이지 좌측 메뉴 추가
- 마이페이지 메뉴 Atom 추가

### 특이사항 (Optional)

- 마이페이지 메뉴 클릭 시 바뀌는 마이페이지 컨텐츠는 src/components/templates/MyPageTemplate 내의 템플릿 수정
  - 등록 상품 : MySellTemplate
  - 관심 상품 : MyWishTemplate
  - 최근 본 상품 : MyRecentTemplate
  - 가계부 : MyCashTemplate
  - 계정관리 : MyAccountTemplate

### Screenshots (Optional)
![image](https://github.com/KIT-Frontend-Team2/Paradise_/assets/11881721/49b6f071-0159-41b0-8730-483a586aba8e)