### PR TITLE
 📝fix : 마이페이지 헤더 useQuery 버그 수정

### DIFF
--- a/src/hooks/pageQuery/useLoadUser.js
+++ b/src/hooks/pageQuery/useLoadUser.js
@@ -9,7 +9,7 @@ const LoadUserApi = () => {
 
 	const getMyPageHeader = () => {
 		const { data, isLoading, isError } = useQuery(
-			[API_KEY.LIST],
+			[API_KEY.MYPAGE],
 			() => getMyPage(),
 			{ ...queryConfig },
 		)


### PR DESCRIPTION
### 요약 (Summary)

- 마이페이지 헤더 useQuery 버그 수정

### 바뀐 점 (Changes)

- 오류 내용 : 메인페이지 <-> 마이페이지 이동 시 서로 페이지에서 오류가 있었습니다.
- 오류 원인 : `마이페이지` 헤더 useQuery의 쿼리키를 `메인페이지`와 동일하게 사용하고 있었습니다 (〃⌒▽⌒〃)ゝ 
- 해결 방법 : 마이페이지 헤더 useQuery의 쿼리키를 수정했습니다.